### PR TITLE
UX improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,23 @@ None for now.
 
 ## Known Issues
 
-- The Jolie Language Server tcp port is statically fixed as 9123. This should be a configurable setting at least.
 - Requires the environment variable `JOLIE_HOME` to be set correctly.
 
 ## Release Notes
 
-### 0.9.3
+### 1.1.0
 
-First release.
+- Created extensions configuration parameters:
+  - `Server Port`: the TCP port of the Jolie LSP Server. Default is `9123`.
+  - `Show Debug Messages`: if set to true, show debug information in the output channel `Jolie LSP Client`. The Output view is toggable under View -> Output. The channel selection is via the dropdown menu on the left.
+- When the Jolie LSP Server process is closed when also the client closes.
+- Error message in case the Jolie LSP Server cannot start properly (includes information on how to solve the problem via extension configurations).
 
 ### 1.0.0
 
 - Detection of the necessary Jolie version.
 - Notify the user if the Jolie executable cannot be found.
+
+### 0.9.3
+
+First release.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ None for now.
 - Created extensions configuration parameters:
   - `Server Port`: the TCP port of the Jolie LSP Server. Default is `9123`.
   - `Show Debug Messages`: if set to true, show debug information in the output channel `Jolie LSP Client`. The Output view is toggable under View -> Output. The channel selection is via the dropdown menu on the left.
-- When the Jolie LSP Server process is closed when also the client closes.
+- The Jolie LSP Server process is closed when also the client closes.
 - Error message in case the Jolie LSP Server cannot start properly (includes information on how to solve the problem via extension configurations).
 
 ### 1.0.0

--- a/package.json
+++ b/package.json
@@ -30,7 +30,13 @@
 		"keybindings": [
 			{
 				"key": "ctrl+alt+n",
-				"macos": "cmd+alt+n",
+				"when" : "!isMac",
+				"command": "workbench.action.tasks.runTask",
+				"args": "run"
+			},
+			{
+				"key": "cmd+alt+n",
+				"when" : "isMac",
 				"command": "workbench.action.tasks.runTask",
 				"args": "run"
 			}

--- a/package.json
+++ b/package.json
@@ -97,10 +97,5 @@
 		"tslint": "^5.16.0",
 		"typescript": "^3.5.1",
 		"vscode": "^1.1.35"
-	},
-	"__metadata": {
-		"id": "d0a46642-0d01-489c-9e79-8ac5e26f6836",
-		"publisherDisplayName": "Jolie programming language",
-		"publisherId": "b3d0d12e-52fa-4b91-a205-826051eed892"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,23 @@
 				"scopeName": "source.jolie",
 				"path": "./syntaxes/jolie.tmLanguage.json"
 			}
-		]
+		],
+		"configuration": {
+			"type": "object",
+			"title": "Jolie LSP Client Configuration",
+			"properties": {
+				"jolie.showDebugMessages": {
+					"type": "boolean",
+					"description": "Select set to true to show debugging messages in the Extensions Output Panel",
+					"default": "false"
+				},
+				"jolie.serverPort": {
+					"type": "number",
+					"description": "The TCP port where the Jolie LSP Server will be listening on",
+					"default": 9123
+				}
+			}
+		}
 	},
 	"main": "./out/extension",
 	"activationEvents": [
@@ -81,5 +97,10 @@
 		"tslint": "^5.16.0",
 		"typescript": "^3.5.1",
 		"vscode": "^1.1.35"
+	},
+	"__metadata": {
+		"id": "d0a46642-0d01-489c-9e79-8ac5e26f6836",
+		"publisherDisplayName": "Jolie programming language",
+		"publisherId": "b3d0d12e-52fa-4b91-a205-826051eed892"
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -124,12 +124,13 @@ export async function activate(context: ExtensionContext) {
 	client.start()
 }
 
-export function deactivate(): Thenable<void> | undefined {
-	if( proc ){
-		proc.kill( 'SIGINT' )
-	}
+export async function deactivate(): Promise<void> | undefined {
 	if ( !client ) {
 		return undefined	
 	}
-	return client.stop()
+	return client.stop().then( function(){
+		if( proc ){
+			proc.kill( 'SIGINT' )
+		}
+	})
 }


### PR DESCRIPTION
- Created extensions configuration parameters:
  - `Server Port`: the TCP port of the Jolie LSP Server. Default is `9123`.
  - `Show Debug Messages`: if set to true, show debug information in the output channel `Jolie LSP Client`. The Output view is toggable under View -> Output. The channel selection is via the dropdown menu on the left.
- When the Jolie LSP Server process is closed when also the client closes.
- Error message in case the Jolie LSP Server cannot start properly (includes information on how to solve the problem via extension configurations).