### PR TITLE
quote filename when calling ShellExecution

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,7 +24,7 @@ function createRunTask( title: string ): Task {
 		{ type: "run", task: "runJolie" },
 		title,
 		"Jolie", 
-		new ShellExecution( "jolie " + file, { cwd : dir } ), 
+		new ShellExecution( `jolie "${file}"`, { cwd : dir } ), 
 		[]
 	)
 }


### PR DESCRIPTION
fix an issue when user running task runJolie with spaced filename, as at the moment console will pass filename as a separate arguments. 

before:
jolie .../2_input_choice/fore cast.ol
after:
jolie ".../2_input_choice/fore cast.ol"