### PR TITLE
version matches string in checking version

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,9 +33,9 @@ async function checkRequiredJolieVersion():Promise<void> {
 	try {
 		const p = await execa('jolie', ['--version'])
 		const stderr = p.stderr
-		const result = stderr.match(/Jolie\s+(\d\.\d\.\d).+/)
+		const result = stderr.match(/Jolie\s+(\d\.\d\.[^ ]*)/)
 		if (result.length > 1) {
-			const jolieVersion = result[1]
+			const jolieVersion = semver.coerce(result[1])
 			if( !semver.satisfies(jolieVersion, versionRequirement) ) {
 				window.showErrorMessage(`This extension requires Jolie version ${versionRequirement}, whereas your version is ${jolieVersion}. Some features may not work correctly. Please consider updating your Jolie installation.`)
 			}


### PR DESCRIPTION
The current jolie's version from git repository returns 1.10-git which doesn't match the pattern of (\d\.\d\.\d) and cause checkRequiredJolieVersion to crash.

Note: the current version in Jolie master branch doesn't comply semver specification, as it is missing the PATCH version. Adding a PATCH could as well solve this problem.