### PR TITLE
Refactor inspect definition into an internal service

### DIFF
--- a/server/src/interfaces/lsp.iol
+++ b/server/src/interfaces/lsp.iol
@@ -48,3 +48,10 @@ interface UtilsInterface {
     updateDocument( DocumentModifications ),
     deleteDocument( DidCloseTextDocumentParams )
 }
+
+interface InspectionUtilsIface {
+  RequestResponse:
+    inspect( DocumentData )( InspectionResult )
+  OneWay:
+    sendEmptyDiagnostics( DocumentUri )
+}

--- a/server/src/internal/utils.ol
+++ b/server/src/internal/utils.ol
@@ -32,13 +32,15 @@ outputPort Client {
 interface InspectionUtilsIface {
   RequestResponse:
     inspect
+  OneWay:
+    sendEmptyDiagnostics
 }
 
 service InspectionUtils {
   Interfaces: InspectionUtilsIface
 
   main {
-    [inspect( documentData )( inspectionResult ) {
+    [ inspect( documentData )( inspectionResult ) {
       scope( inspection ) {
         inspectionResult.saveProgram = true
         install( default =>
@@ -298,15 +300,21 @@ main {
         doc.lines[#doc.lines] = line
       }
 
-      inspect
+      //inspect
+      inspect@InspectionUtils( {
+        uri = uri
+        text = docText
+      } )( inspectionResult )
 
-      sendDiagnostics
+      //sendDiagnostics
       if( inspectionResult.saveProgram ) {
+        sendEmptyDiagnostics@InspectionUtils( inspectionResult.uri )
         doc.jolieProgram << inspectionResult.result
       }
 
       doc << {
-        uri = uri
+        //uri = uri
+        uri = inspectionResult.uri //I saved the realaborated uri
         source = docText
         version = version
       }
@@ -336,10 +344,15 @@ main {
           doc.lines[#doc.lines] = line
         }
 
-        inspect
+        //inspect
+        inspect@InspectionUtils( {
+          uri = uri
+          text = docText
+        } )( inspectionResult )
 
-        sendDiagnostics
+        //sendDiagnostics
         if( inspectionResult.saveProgram ) {
+          sendEmptyDiagnostics@InspectionUtils( inspectionResult.uri )
           doc.jolieProgram << inspectionResult.result
         }
         doc << {
@@ -348,15 +361,16 @@ main {
         }
 
         docsSaved[indexDoc] << doc
-      } else {
-        inspect
+      }// else {
+        //inspect
 
-        sendDiagnostics
-        if( inspectionResult.saveProgram ) {
-          doc.jolieProgram << inspectionResult.result
-        }
+        //sendDiagnostics
+        //if( inspectionResult.saveProgram ) {
+        //  sendEmptyDiagnostics@InspectionUtils()
+        //  doc.jolieProgram << inspectionResult.result
+        //}
         // doc.jolie << inspectionResult
-      }
+      //}
   }
 
   [ deleteDocument( txtDocParams ) ] {

--- a/server/src/internal/utils.ol
+++ b/server/src/internal/utils.ol
@@ -57,15 +57,20 @@ service InspectionUtils {
             word = "file:"
           } )( indexOfRes )
           if ( indexOfRes > -1 ) {
-            subStrReq = matchRes.group[1]
-            subStrReq.begin = indexOfRes + 5
+            //subStrReq = matchRes.group[1]
+            //subStrReq.begin = indexOfRes + 5
 
-            substring@StringUtils( subStrReq )( documentUri ) //line
+            substring@StringUtils( matchRes.group[1] {
+              begin = indexOfRes + 5
+            } )( documentUri ) //line
           } else {
-            replaceRequest = matchRes.group[1]
-            replaceRequest.regex = "\\\\";
-            replaceRequest.replacement = "/"
-            replaceAll@StringUtils( replaceRequest )( documentUri )
+            //replaceRequest = matchRes.group[1]
+            //replaceRequest.regex = "\\\\";
+            //replaceRequest.replacement = "/"
+            replaceAll@StringUtils( matchRes.group[1] {
+              regex = "\\\\"
+              replacement = "/"
+            } )( documentUri )
             // documentUri = "///" + fileName
           }
           
@@ -84,19 +89,19 @@ service InspectionUtils {
           diagnosticParams << {
             uri = "file:" + documentUri
             diagnostics << {
-            range << {
-              start << {
-              line = l-1
-              character = 1
+              range << {
+                start << {
+                  line = l-1
+                  character = 1
+                }
+                end << {
+                  line = l-1
+                  character = INTEGER_MAX_VALUE
+                }
               }
-              end << {
-              line = l-1
-              character = INTEGER_MAX_VALUE
-              }
-            }
-            severity = s
-            source = "jolie"
-            message = matchRes.group[4]
+              severity = s
+              source = "jolie"
+              message = matchRes.group[4]
             }
           }
           publishDiagnostics@Client( diagnosticParams )
@@ -110,22 +115,34 @@ service InspectionUtils {
         getenv@Runtime( "JOLIE_HOME" )( jHome )
         getFileSeparator@File()( fs )
         getParentPath@File( documentData.uri )( documentPath )
-        regexRequest = documentData.uri
-        regexRequest.regex =  "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?"
-        find@StringUtils( regexRequest )( regexResponse ) 
+        //regexRequest = documentData.uri
+        //regexRequest.regex =  "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?"
+        find@StringUtils( documentData.uri {
+          regex = "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?"
+        } )( regexResponse )
+
+        //replacementRequest = regexResponse.group[5]
+        //replacementRequest.regex = "%20"
+        //replacementRequest.replacement = " "
+        replaceAll@StringUtils( regexResponse.group[5] {
+          regex = "%20"
+          replacement = " "
+        } )( inspectionReq.filename )
+
         inspectionReq << {
-          filename = regexResponse.group[5]
+          //filename = regexResponse.group[5]
           source = documentData.text
           includePaths[0] = jHome + fs + "include"
-          includePaths[1] = documentPath
+          //includePaths[1] = documentPath
         }
-        replacementRequest = regexResponse.group[5]
-        replacementRequest.regex = "%20"
-        replacementRequest.replacement = " "
-        replaceAll@StringUtils(replacementRequest)(inspectionReq.filename)
+        
+        replaceAll@StringUtils( documentPath {
+          regex = "%20"
+          replacement = " "
+        } )( inspectorReq.includePaths[1] )
 
-        replacementRequest = inspectionReq.includePaths[1]
-        replaceAll@StringUtils(replacementRequest)(inspectionReq.includePaths[1])
+        //replacementRequest = inspectionReq.includePaths[1]
+        //replaceAll@StringUtils(replacementRequest)(inspectionReq.includePaths[1])
         inspectPorts@Inspector( inspectionReq )( inspectionResult.result )
       }
     }]
@@ -152,65 +169,70 @@ define inspect
   scope( inspection ) {
     saveProgram = true
     install( default =>
-		stderr = inspection.(inspection.default)
-		stderr.regex =  "\\s*(.+):\\s*(\\d+):\\s*(error|warning)\\s*:\\s*(.+)"
-		find@StringUtils( stderr )( matchRes )
-		// //getting the uri of the document to be checked
-		//have to do this because the inspector, when returning an error,
-		//returns an uri that looks the following:
-		// /home/eferos93/.atom/packages/Jolie-ide-atom/server/file:/home/eferos93/.atom/packages/Jolie-ide-atom/server/utils.ol
-		//same was with jolie --check
-		if ( !(matchRes.group[1] instanceof string) ) {
-			matchRes.group[1] = ""
-		}
-		indexOf@StringUtils( matchRes.group[1] {
-			word = "file:"
-		} )( indexOfRes )
-		if ( indexOfRes > -1 ) {
-			subStrReq = matchRes.group[1]
-			subStrReq.begin = indexOfRes + 5
+      stderr = inspection.(inspection.default)
+      stderr.regex =  "\\s*(.+):\\s*(\\d+):\\s*(error|warning)\\s*:\\s*(.+)"
+      find@StringUtils( stderr )( matchRes )
+      // //getting the uri of the document to be checked
+      //have to do this because the inspector, when returning an error,
+      //returns an uri that looks the following:
+      // /home/eferos93/.atom/packages/Jolie-ide-atom/server/file:/home/eferos93/.atom/packages/Jolie-ide-atom/server/utils.ol
+      //same was with jolie --check
+      if ( !(matchRes.group[1] instanceof string) ) {
+        matchRes.group[1] = ""
+      }
+      indexOf@StringUtils( matchRes.group[1] {
+        word = "file:"
+      } )( indexOfRes )
+      if ( indexOfRes > -1 ) {
+        //subStrReq = matchRes.group[1]
+        //subStrReq.begin = indexOfRes + 5
 
-			substring@StringUtils( subStrReq )( documentUri ) //line
-		} else {
-			replaceRequest = matchRes.group[1]
-			replaceRequest.regex = "\\\\";
-			replaceRequest.replacement = "/"
-			replaceAll@StringUtils( replaceRequest )( documentUri )
-			// documentUri = "///" + fileName
-		}
-		
-		//line
-		l = int( matchRes.group[2] )
-		//severity
-		sev -> matchRes.group[3]
-		//TODO alwayes return error, never happend to get a warning
-		//but this a problem of the jolie parser
-		if ( sev == "error" ) {
-			s = 1
-		} else {
-			s = 1
-		}
+        substring@StringUtils( matchRes.group[1] {
+          begin = indexOfRes + 5
+        } )( documentUri ) //line
+      } else {
+        //replaceRequest = matchRes.group[1]
+        //replaceRequest.regex = "\\\\";
+        //replaceRequest.replacement = "/"
+        replaceAll@StringUtils( matchRes.group[1] {
+          regex = "\\\\"
+          replacement = "/"
+        } )( documentUri )
+        // documentUri = "///" + fileName
+      }
+      
+      //line
+      l = int( matchRes.group[2] )
+      //severity
+      sev -> matchRes.group[3]
+      //TODO alwayes return error, never happend to get a warning
+      //but this a problem of the jolie parser
+      if ( sev == "error" ) {
+        s = 1
+      } else {
+        s = 1
+      }
 
-		diagnosticParams << {
-			uri = "file:" + documentUri
-			diagnostics << {
-			range << {
-				start << {
-				line = l-1
-				character = 1
-				}
-				end << {
-				line = l-1
-				character = INTEGER_MAX_VALUE
-				}
-			}
-			severity = s
-			source = "jolie"
-			message = matchRes.group[4]
-			}
-		}
-		publishDiagnostics@Client( diagnosticParams )
-		saveProgram = false
+      diagnosticParams << {
+        uri = "file:" + documentUri
+        diagnostics << {
+          range << {
+            start << {
+              line = l-1
+              character = 1
+            }
+            end << {
+              line = l-1
+              character = INTEGER_MAX_VALUE
+            }
+          }
+          severity = s
+          source = "jolie"
+          message = matchRes.group[4]
+        }
+      }
+      publishDiagnostics@Client( diagnosticParams )
+      saveProgram = false
     )
 
     // TODO : fix these:
@@ -220,21 +242,30 @@ define inspect
     getFileSeparator@File()( fs )
     getParentPath@File( uri )( documentPath )
     regexRequest = uri
-	regexRequest.regex =  "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?"
+	  regexRequest.regex =  "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?"
     find@StringUtils( regexRequest )( regexResponse ) 
+    
+    //replacementRequest = regexResponse.group[5]
+    //replacementRequest.regex = "%20"
+    //replacementRequest.replacement = " "
+    replaceAll@StringUtils( regexResponse.group[5] {
+      regex = "%20"
+      replacement = " "
+    } )( inspectionReq.filename )
+
     inspectionReq << {
-      filename = regexResponse.group[5]
+      //filename = regexResponse.group[5]
       source = docText
       includePaths[0] = jHome + fs + "include"
-      includePaths[1] = documentPath
+      //includePaths[1] = documentPath
     }
-    replacementRequest = regexResponse.group[5]
-    replacementRequest.regex = "%20"
-    replacementRequest.replacement = " "
-    replaceAll@StringUtils(replacementRequest)(inspectionReq.filename)
-
-    replacementRequest = inspectionReq.includePaths[1]
-    replaceAll@StringUtils(replacementRequest)(inspectionReq.includePaths[1])
+    
+    replaceAll@StringUtils( documentPath {
+      regex = "%20"
+      replacement = " "
+    } )( inspectionReq.includePaths[1] )
+    //replacementRequest = inspectionReq.includePaths[1]
+    //replaceAll@StringUtils( replacementRequest )( inspectionReq.includePaths[1] )
     inspectPorts@Inspector( inspectionReq )( inspectionRes )
   }
 }

--- a/server/src/internal/utils.ol
+++ b/server/src/internal/utils.ol
@@ -113,7 +113,7 @@ service InspectionUtils {
         getParentPath@File( documentData.uri )( documentPath )
         regexRequest = documentData.uri
 	      regexRequest.regex =  "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?"
-        find@StringUtils( regexRequest)( regexResponse )
+        find@StringUtils( regexRequest )( regexResponse )
 
         //Spaces in file URIs are encoded with %20 in some systems
         replaceAll@StringUtils( regexResponse.group[5] {

--- a/server/src/internal/utils.ol
+++ b/server/src/internal/utils.ol
@@ -101,6 +101,7 @@ service InspectionUtils {
           }
           publishDiagnostics@Client( diagnosticParams )
           inspectionResult.saveProgram = false
+          inspectionResult.diagnostics << diagnosticParams
         )
 
         // TODO : fix these:
@@ -129,16 +130,17 @@ service InspectionUtils {
       }
     }]
 
-    [sendDiagnostics( inspectionResult )] {
+    [sendEmptyDiagnostics( uri )] {
       print@Console( "ciao" )(  )
-      if ( inspectionResult.saveProgram ) {
+      //if ( inspectionResult.saveProgram ) {
         //doc.jolieProgram << inspectionResult.result
         diagnosticParams << {
-          uri = inspectionResult.uri
+          //uri = inspectionResult.uri
+          uri = uri
           diagnostics = void
       }
       publishDiagnostics@Client( diagnosticParams )
-  }
+      //}
 
     }
   }
@@ -306,7 +308,9 @@ main {
         inspect
 
         sendDiagnostics
-
+        if( inspectionResult.saveProgram ) {
+          doc.jolieProgram << inspectionResult.result
+        }
         doc << {
           source = docText
           version = newVersion
@@ -317,6 +321,9 @@ main {
         inspect
 
         sendDiagnostics
+        if( inspectionResult.saveProgram ) {
+          doc.jolieProgram << inspectionResult.result
+        }
         // doc.jolie << inspectionResult
       }
   }
@@ -344,7 +351,7 @@ main {
       }
 
       if ( !found ) {
-        //TODO if found == false throw exception
+        //TODO: if found == false throw exception
         println@Console( "doc not found!!!" )()
       }
   } ]

--- a/server/src/internal/utils.ol
+++ b/server/src/internal/utils.ol
@@ -29,14 +29,120 @@ outputPort Client {
   Interfaces: ServerToClient
 }
 
-// interface InspectionUtilsIface {
-// RequestResponse:
-//   inspect
-// }
+interface InspectionUtilsIface {
+  RequestResponse:
+    inspect
+}
 
-// service InspectionUtils {
-// interfaces: InspectionUtilsIface
-// }
+service InspectionUtils {
+  Interfaces: InspectionUtilsIface
+
+  main {
+    [inspect( documentData )( inspectionResult ) {
+      scope( inspection ) {
+        inspectionResult.saveProgram = true
+        install( default =>
+          stderr = inspection.(inspection.default)
+          stderr.regex =  "\\s*(.+):\\s*(\\d+):\\s*(error|warning)\\s*:\\s*(.+)"
+          find@StringUtils( stderr )( matchRes )
+          // //getting the uri of the document to be checked
+          //have to do this because the inspector, when returning an error,
+          //returns an uri that looks the following:
+          // /home/eferos93/.atom/packages/Jolie-ide-atom/server/file:/home/eferos93/.atom/packages/Jolie-ide-atom/server/utils.ol
+          //same was with jolie --check
+          if ( !(matchRes.group[1] instanceof string) ) {
+            matchRes.group[1] = ""
+          }
+          indexOf@StringUtils( matchRes.group[1] {
+            word = "file:"
+          } )( indexOfRes )
+          if ( indexOfRes > -1 ) {
+            subStrReq = matchRes.group[1]
+            subStrReq.begin = indexOfRes + 5
+
+            substring@StringUtils( subStrReq )( documentUri ) //line
+          } else {
+            replaceRequest = matchRes.group[1]
+            replaceRequest.regex = "\\\\";
+            replaceRequest.replacement = "/"
+            replaceAll@StringUtils( replaceRequest )( documentUri )
+            // documentUri = "///" + fileName
+          }
+          
+          //line
+          l = int( matchRes.group[2] )
+          //severity
+          sev -> matchRes.group[3]
+          //TODO always return error, never happend to get a warning
+          //but this a problem of the jolie parser
+          if ( sev == "error" ) {
+            s = 1
+          } else {
+            s = 1
+          }
+
+          diagnosticParams << {
+            uri = "file:" + documentUri
+            diagnostics << {
+            range << {
+              start << {
+              line = l-1
+              character = 1
+              }
+              end << {
+              line = l-1
+              character = INTEGER_MAX_VALUE
+              }
+            }
+            severity = s
+            source = "jolie"
+            message = matchRes.group[4]
+            }
+          }
+          publishDiagnostics@Client( diagnosticParams )
+          inspectionResult.saveProgram = false
+        )
+
+        // TODO : fix these:
+        // - remove the directories of this LSP
+        // - add the directory of the open file.
+        getenv@Runtime( "JOLIE_HOME" )( jHome )
+        getFileSeparator@File()( fs )
+        getParentPath@File( documentData.uri )( documentPath )
+        regexRequest = documentData.uri
+        regexRequest.regex =  "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?"
+        find@StringUtils( regexRequest )( regexResponse ) 
+        inspectionReq << {
+          filename = regexResponse.group[5]
+          source = documentData.text
+          includePaths[0] = jHome + fs + "include"
+          includePaths[1] = documentPath
+        }
+        replacementRequest = regexResponse.group[5]
+        replacementRequest.regex = "%20"
+        replacementRequest.replacement = " "
+        replaceAll@StringUtils(replacementRequest)(inspectionReq.filename)
+
+        replacementRequest = inspectionReq.includePaths[1]
+        replaceAll@StringUtils(replacementRequest)(inspectionReq.includePaths[1])
+        inspectPorts@Inspector( inspectionReq )( inspectionResult.result )
+      }
+    }]
+
+    [sendDiagnostics( inspectionResult )] {
+      print@Console( "ciao" )(  )
+      if ( inspectionResult.saveProgram ) {
+        //doc.jolieProgram << inspectionResult.result
+        diagnosticParams << {
+          uri = inspectionResult.uri
+          diagnostics = void
+      }
+      publishDiagnostics@Client( diagnosticParams )
+  }
+
+    }
+  }
+}
 
 // TODO: refactor this definition to an internal service
 define inspect
@@ -162,6 +268,9 @@ main {
       inspect
 
       sendDiagnostics
+      if( inspectionResult.saveProgram ) {
+        doc.jolieProgram << inspectionResult.result
+      }
 
       doc << {
         uri = uri
@@ -208,6 +317,7 @@ main {
         inspect
 
         sendDiagnostics
+        // doc.jolie << inspectionResult
       }
   }
 

--- a/server/src/internal/utils.ol
+++ b/server/src/internal/utils.ol
@@ -39,8 +39,13 @@ interface InspectionUtilsIface {
 service InspectionUtils {
   Interfaces: InspectionUtilsIface
 
+  init {
+    println@Console( "InspectionUtils Service started" )()
+  }
+
   main {
     [ inspect( documentData )( inspectionResult ) {
+      println@Console( "Inspecting..." )(  )
       scope( inspection ) {
         inspectionResult.saveProgram = true
         install( default =>
@@ -150,7 +155,7 @@ service InspectionUtils {
     }]
 
     [sendEmptyDiagnostics( uri )] {
-      print@Console( "ciao" )(  )
+      println@Console( "Sending empty diagnostics" )(  )
       //if ( inspectionResult.saveProgram ) {
         //doc.jolieProgram << inspectionResult.result
         diagnosticParams << {

--- a/server/src/types/lsp.iol
+++ b/server/src/types/lsp.iol
@@ -847,5 +847,5 @@ type DocumentData {
 
 type InspectionResult {
   diagnostics?: undefined //diagnostic message
-  result: undefined //jolie program
+  result?: undefined //jolie program
 }

--- a/server/src/types/lsp.iol
+++ b/server/src/types/lsp.iol
@@ -839,3 +839,13 @@ type DocumentModifications {
   uri: string
   text: string
 }
+
+type DocumentData {
+  uri: string
+  text: string
+}
+
+type InspectionResult {
+  diagnostics?: undefined //diagnostic message
+  result: undefined //jolie program
+}


### PR DESCRIPTION
Refactored the utils.ol. Removed the definitions `inspect` and `sendDiagnostic` for being replaced with an internal service `InspectionUtils` with operations `inspect` and `sendEmptyDiagnostics`.
Tested on Linux, couldn't test on Windows due to #12 