### PR TITLE
Added --trace for windows debugging with local languageserver.

### DIFF
--- a/src/ls_process.ts
+++ b/src/ls_process.ts
@@ -47,7 +47,7 @@ export default class LanguageServerProcess extends EventEmitter {
       // languageServer is a path to launcher
       if (isWindows) {
         this.command = "cmd.exe";
-        this.args = ["/C", "jolie", languageServer, `${port}`];
+        this.args = ["/C", "jolie", "--trace", languageServer, `${port}`];
       } else {
         this.command = "jolie";
         this.args = ["--trace", languageServer, `${port}`];


### PR DESCRIPTION
Currently, there is a difference in behavior between Windows and Linux (found by @lynetma2) when using "Run and Debug" with local language server in Visual Studio Code. On Linux it runs the language server with `--trace`, while it doesn't on Windows. 
This PR adds it in the Windows case.